### PR TITLE
デプロイ用設定１

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,7 +93,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Only use :id for inspections in production.
-  config.active_record.attributes_for_inspect = [ :id ]
+  # config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [


### PR DESCRIPTION
config/environments/production.rbの下記設定を削除
~~~
config.active_record.attributes_for_inspect = [ :id ]
# rails7.1以降の設定のため
~~~