### PR TITLE
fix: [#79] 本番環境でgem deviseがメールを送信できるようにする設定がかけていたため追加しました。

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,9 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
+  # 本番環境でメールを送信するために必要な設定
   config.mailer_sender = ENV["MAILER_SENDER"] || "noreply@cocfightsimulator.onrender.com"
+  config.mailer = "Devise::Mailer"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## 概要
gem deviseを用いたパスワード再設定メールの送信が本番環境でおこなえずエラーが発生していたため修正を行ないました。

## 関連Issue
このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #123

## 原因と対処法（バグ修正の場合）

> 原因

 本番環境でメールを送信できる設定がされていなかったため

> 対処
1.config/environments/production.rbとconfig/initializers/devise.rbに実際にメール送信を行うために必要な記述をする
2.renderの環境変数を設定
3.1,2両者を行いデプロイ

## やったこと（変更点）。
- 実際にメール送信を行うために必要な記述を追加しました。
[ config/environments/production.rb, config/initializers/devise.rb ]

- renderの環境変数に以下の値を追加しました。
{ 
APP_HOST=cocfightsimulator.onrender.com
SMTP_ADDRESS=smtp.gmail.com
SMTP_DOMAIN=cocfightsimulator.onrender.com
SMTP_PASSWORD=[16桁のアプリパスワード]
SMTP_PORT=587
SMTP_USER_NAME=[メールアドレス]
MAILER_SENDER=noreply@cocfightsimulator.onrender.com
}


## 動作確認

- rubocop　テスト済み
- rspec　テスト済み
- localhost3000/ローカル環境での動作確認済み
- 本番環境 / (render)での動作確認はmainブランチにコミットされた後に確認予定です。(mainブランチにコミット時に更新されるため)

## 注意事項
今回のプルリクエストは、デプロイを行い変更を反映させるためのものであり、pull origin mainを行った後もエラーが残ってしまう可能性があります。
エラーが残った場合、再度このissueで修正を行います。