### PR TITLE
fix: [#79] render無料プランの仕様回避のためにメール送信設定を変更しました。

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,7 +117,7 @@ Rails.application.configure do
   # SMTP設定（メール送信に必要）
   config.action_mailer.smtp_settings = {
     address: ENV["SMTP_ADDRESS"],          # 例: 'smtp.gmail.com'
-    port: ENV["SMTP_PORT"] || 587,         # 通常は587
+    port: ENV["SMTP_PORT"] || 2525,         # render仕様回避設定
     domain: ENV["SMTP_DOMAIN"],            # 例: 'your-app-name.onrender.com'
     user_name: ENV["SMTP_USER_NAME"],      # SMTPのユーザー名
     password: ENV["SMTP_PASSWORD"],        # SMTPのパスワード

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,7 +25,7 @@ Devise.setup do |config|
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
   # 本番環境でメールを送信するために必要な設定
-  config.mailer_sender = ENV["MAILER_SENDER"] || "noreply@cocfightsimulator.onrender.com"
+  config.mailer_sender = ENV["MAILER_SENDER"] || "noreply@cocfightsimulator.com"
   config.mailer = "Devise::Mailer"
 
   # Configure the class responsible to send e-mails.


### PR DESCRIPTION
## 概要
本番環境におけるメール送信機能の問題の修正を行いました。

## 関連Issue

- 関連Issue: #79

## 原因と対処法（バグ修正の場合）

> 原因

renderの無料プランの仕様により、ポート 25, 465, 587 を使用した外部のSMTPサーバーへの接続がすべてブロックされる仕様であったため、ポート587を使用したメール送信がブロックされていた

> 対処
使用するポート番号を2525に変更しました。

## やったこと（変更点）
このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- renderの環境変数を更新しました。
- ポート番号を2525番に変更し、その際に遅延などの問題が発生しないように修正しました。


## 動作確認

- rubocop　テスト済み
- rspec　テスト済み
- localhost3000/ローカル環境での動作確認済み
- 本番環境 / (render)での動作確認はmainブランチにコミットされた後に確認予定です。(mainブランチにコミット時に更新されるため)