### PR TITLE
fix: 重複したユーザー名でログインできる仕様であったため、ユーザー名ではなくメールアドレスでログインするようにしました。

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :email ])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :email ])
     # ↓ MVPリリースまでの仮設定　できればdeviseのconfirmableモジュールを有効化するか、emailを使用しないユーザー認証に変える(万一アカウント乗っ取りがあっても、当アプリでしか使用しない情報しか渡さない)
     devise_parameter_sanitizer.permit(:account_update, keys: [ :email ])
   end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,8 +3,8 @@
 <%= form_with model: @user, url: user_session_path do |f| %>
 
   <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -48,7 +48,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  config.authentication_keys = [ :name ]
+  config.authentication_keys = [ :email ]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,7 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   root "static_pages#top"
-  resource :simulations
-  post "roll", to: "simulations#roll"
+  resource :simulations, only: %i[new]
   post "combat_roll", to: "simulations#combat_roll"
   resources :characters
 


### PR DESCRIPTION
## 概要
ログイン時に、重複したユーザー名でログインできてしまう問題を修正しました。

## 原因と対処法（バグ修正の場合）
ユーザー名の一意生バリデートを設定していないにも関わらず、deviseの設定でログイン時に要求する値にユーザー名を設定していたこと

## やったこと（変更点）

- ログイン時に要求する値を「ユーザー名とパスワード」から「メールアドレスとパスワード」に変更しました。
[app/controllers/application_controller.rb, app/views/devise/sessions/new.html.erb, config/initializers/devise.rb]

- 現在使用していない不要なルートを削除しました。
[ config/routes.rb ]

##　変更結果
ログイン時に「メールアドレス」と「パスワード」を入力するとログインできるようになりました。


## 動作確認
- rubocop　テスト済み
- rspec　テスト済み
- localhost3000/ローカル環境での動作確認済み
- 本番環境 / (render)での動作確認はmainブランチにコミットされた後に確認予定です。(mainブランチにコミット時に更新されるため)