### PR TITLE
ユーザー登録時の不具合

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :email ])
     # ↓ MVPリリースまでの仮設定　できればdeviseのconfirmableモジュールを有効化するか、emailを使用しないユーザー認証に変える(万一アカウント乗っ取りがあっても、当アプリでしか使用しない情報しか渡さない)
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :email ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :email ])
   end
 
   add_flash_types :success, :danger


### PR DESCRIPTION
## 概要
ユーザー登録/ユーザー情報変更時にユーザーネームが認識されずユーザー登録/ユーザー情報変更ができない問題があったため修正しました。

## 原因と対処法（バグ修正の場合）

> 原因

devise_parameter_sanitizer.permit(:sign_up, keys: [ :email ])というように、本来必要な[:name]キーを削除指定しまったこと

> 対処法

[:name]キーを追加しました。

## やったこと（変更点）

- ユーザー登録/編集に必要なパラメータを許可しました。
[ app/controllers/application_controller.rb ]

##　変更結果
ユーザー登録: ユーザー登録が正常に行えるようになりました。
ユーザー編集: ユーザー名の変更が反映されるようになりました。


- rubocop　テスト済み
- rspec　テスト済み
- localhost3000/ローカル環境での動作確認済み
- 本番環境 / (render)での動作確認はmainブランチにコミットされた後に確認予定です。(mainブランチにコミット時に更新されるため)
