### PR TITLE
fix: [#129] ホバー時にローディングアニメーションが誤表示される不具合を修正

### DIFF
--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -24,15 +24,17 @@ export default class extends Controller {
     document.addEventListener("turbo:submit-end", this.boundHide)
 
     // ページ遷移（Turbo Drive）
-    document.addEventListener("turbo:before-fetch-request", this.boundShow)
-    document.addEventListener("turbo:before-fetch-response", this.boundHide)
+    // turbo:before-fetch-request はホバー時のプリフェッチでも発火するため使用しない
+    // turbo:visit は実際のナビゲーション開始時のみ発火する
+    document.addEventListener("turbo:visit", this.boundShow)
+    document.addEventListener("turbo:load", this.boundHide)
   }
 
   disconnect() {
     document.removeEventListener("turbo:submit-start", this.boundShow)
     document.removeEventListener("turbo:submit-end", this.boundHide)
-    document.removeEventListener("turbo:before-fetch-request", this.boundShow)
-    document.removeEventListener("turbo:before-fetch-response", this.boundHide)
+    document.removeEventListener("turbo:visit", this.boundShow)
+    document.removeEventListener("turbo:load", this.boundHide)
     clearTimeout(this.showDelayTimer)
     clearTimeout(this.hideDelayTimer)
   }


### PR DESCRIPTION
## タイトル
ホバー時にローディングアニメーションが誤表示される不具合を修正

## 概要
本番環境（Render）において、リンクやボタンにマウスカーソルを合わせた際にローディングアニメーションが一瞬表示される不具合を修正した。

## 関連Issue

- 関連Issue: #129
- close #129

## 原因と対処法（バグ修正の場合）

**原因:**
`turbo:before-fetch-request` イベントは、Turbo Drive のリンクホバー時のプリフェッチ機能でも発火する。
- localhost では、プリフェッチが 200ms（`SHOW_DELAY_MS`）以内に完了するためアニメーションが表示されない
- Render（本番）では、サーバーの応答が遅く 200ms を超えることがあり、アニメーションが表示されてしまう

**対処法:**
- `turbo:before-fetch-request` → `turbo:visit` に変更
  - `turbo:visit` は実際のリンククリック（ナビゲーション開始）時のみ発火し、プリフェッチでは発火しない
- `turbo:before-fetch-response` → `turbo:load` に変更
  - ページ描画完了後にローディングを非表示にするよう修正

## やったこと（変更点）

- `app/javascript/controllers/loading_controller.js`
  - ページ遷移トリガーのイベントを `turbo:before-fetch-request` → `turbo:visit` に変更
  - ページ遷移完了のイベントを `turbo:before-fetch-response` → `turbo:load` に変更
  - `disconnect()` のイベント解除も同様に更新
  - コメントにプリフェッチ問題についての説明を追記

## 作業サマリー

| 変更前 | 変更後 | 理由 |
|---|---|---|
| `turbo:before-fetch-request` | `turbo:visit` | ホバープリフェッチでも発火するため |
| `turbo:before-fetch-response` | `turbo:load` | ページ描画完了のタイミングに合わせるため |

`SHOW_DELAY_MS = 200` の値自体は適切であり、イベントの選択が問題の原因だった。

## 動作確認

- rubocop　テスト済み
- rspec　テスト済み
- localhost3000/ローカル環境での動作確認済み
- 本番環境 / (render)での動作確認はmainブランチにコミットされた後に確認予定です。(mainブランチにコミット時に更新されるため)

## 注意事項

特になし