### PR TITLE
feature: [#128] コレクションチュートリアル機能を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
 
   # 特典券付与 + チュートリアル中でなければ通知フラグをセット
   def grant_tickets(action)
-    return [] if current_user.tutorial_active?
+    return [] if current_user.any_tutorial_active?
 
     granted = RewardTicketGranter.call(current_user, action: action)
     flash[:reward_ticket_granted] = granted.size if granted.any?

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -5,6 +5,12 @@ class TutorialsController < ApplicationController
       current_user.advance_tutorial!
     when "dismiss"
       current_user.dismiss_tutorial!
+    when "start_collection"
+      current_user.start_collection_tutorial!
+    when "advance_collection"
+      current_user.advance_collection_tutorial!
+    when "dismiss_collection"
+      current_user.dismiss_collection_tutorial!
     end
     head :ok
   end

--- a/app/javascript/controllers/collection_tutorial_controller.js
+++ b/app/javascript/controllers/collection_tutorial_controller.js
@@ -1,0 +1,276 @@
+import { Controller } from "@hotwired/stimulus"
+import Shepherd from "shepherd.js"
+
+export default class extends Controller {
+  static values = { i18n: Object }
+
+  connect() {
+    this.tryStart()
+    this.boundForceStart = () => this.forceStart()
+    document.addEventListener("collection-tutorial:start", this.boundForceStart)
+  }
+
+  disconnect() {
+    document.removeEventListener("collection-tutorial:start", this.boundForceStart)
+    this.cleanupListeners()
+    if (this.tour) this.tour.hide()
+  }
+
+  // ===== 起動制御 =====
+
+  tryStart() {
+    const meta = document.querySelector('meta[name="collection-tutorial-step"]')
+    if (!meta) return
+    const step = parseInt(meta.content, 10)
+    if (!this.shouldShowTour(step)) return
+    this.startTour(step)
+  }
+
+  // 既存チュートリアル完了/スキップ直後にカスタムイベント経由で起動（同一ページ上）
+  forceStart() {
+    this.startTour(1)
+  }
+
+  shouldShowTour(step) {
+    const path = window.location.pathname
+    if (step === 1) return true // どのページでもOK（ヘッダー要素は全ページに存在する）
+    if (step === 2) return path === "/profile"
+    return false
+  }
+
+  startTour(step) {
+    const steps = step === 1 ? this.phase1Steps() : this.phase2Steps()
+    if (steps.length === 0) return
+
+    this.tour = new Shepherd.Tour({
+      useModalOverlay: true,
+      defaultStepOptions: {
+        scrollTo: { behavior: "smooth", block: "center" },
+        cancelIcon: { enabled: true },
+        classes: "tutorial-step"
+      }
+    })
+    steps.forEach(s => this.tour.addStep(s))
+    this.tour.on("cancel", () => this.dismissTutorial())
+    this.tour.start()
+  }
+
+  // ===== フェーズ1: モーダル操作 + 情報説明（任意のページ） =====
+
+  phase1Steps() {
+    const s = this.i18nValue
+    const hasTickets = !!document.querySelector('button[data-bs-target="#rewardTicketModal"] .badge')
+
+    const modalSteps = hasTickets ? this.modalInteractionSteps(s) : []
+    return [...modalSteps, ...this.infoSteps(s)]
+  }
+
+  // モーダル操作ステップ（特典券バッジ → 使用 → ダイス入手確認）
+  modalInteractionSteps(s) {
+    return [
+      // ステップ1: 🎫バッジをクリックするよう誘導
+      {
+        id: "ticket-click",
+        title: s.step1?.ticket_click_title,
+        text: s.step1?.ticket_click_text,
+        attachTo: { element: 'button[data-bs-target="#rewardTicketModal"]', on: "bottom" },
+        buttons: [],
+        when: {
+          show: () => {
+            this.modalShownHandler = (e) => {
+              if (e.target.id === "rewardTicketModal") {
+                this.tour.next()
+              }
+            }
+            document.addEventListener("shown.bs.modal", this.modalShownHandler)
+          },
+          hide: () => {
+            document.removeEventListener("shown.bs.modal", this.modalShownHandler)
+          }
+        }
+      },
+      // ステップ2: 「特典券を使用する」ボタンをクリックするよう誘導
+      {
+        id: "ticket-use",
+        title: s.step1?.ticket_use_title,
+        text: s.step1?.ticket_use_text,
+        attachTo: { element: "#rewardTicketModal .btn-warning", on: "bottom" },
+        buttons: [],
+        when: {
+          show: () => {
+            this.lowerOverlayZIndex()
+            this.diceModalShownHandler = (e) => {
+              if (e.target.id === "diceAcquiredModal") {
+                this.tour.next()
+              }
+            }
+            document.addEventListener("shown.bs.modal", this.diceModalShownHandler)
+          },
+          hide: () => {
+            document.removeEventListener("shown.bs.modal", this.diceModalShownHandler)
+            this.restoreOverlayZIndex()
+          }
+        }
+      },
+      // ステップ3: 入手ダイスモーダルの「閉じる」ボタンをクリックするよう誘導
+      {
+        id: "dice-result",
+        title: s.step1?.dice_result_title,
+        text: s.step1?.dice_result_text,
+        attachTo: { element: "#diceAcquiredModal .modal-footer .btn-primary", on: "top" },
+        buttons: [],
+        when: {
+          show: () => {
+            this.lowerOverlayZIndex()
+            this.diceModalHiddenHandler = (e) => {
+              if (e.target.id === "diceAcquiredModal") {
+                this.tour.next()
+              }
+            }
+            document.addEventListener("hidden.bs.modal", this.diceModalHiddenHandler)
+          },
+          hide: () => {
+            document.removeEventListener("hidden.bs.modal", this.diceModalHiddenHandler)
+            this.restoreOverlayZIndex()
+          }
+        }
+      }
+    ]
+  }
+
+  // 情報説明ステップ（サイトロゴ → 入手方法 → プロフィールへ遷移）
+  infoSteps(s) {
+    return [
+      // ステップ4: サイトロゴの説明
+      {
+        id: "info-site-logo",
+        title: s.step1?.site_logo_title,
+        text: s.step1?.site_logo_text,
+        attachTo: { element: "#logo-link", on: "bottom" },
+        buttons: [
+          { text: s.skip, action: () => this.dismissTutorial(), classes: "shepherd-button-secondary" },
+          { text: s.next, action: () => this.tour.next(), classes: "shepherd-button-primary" }
+        ],
+      },
+      // ステップ5: 特典券入手方法の説明（中央表示）
+      {
+        id: "info-how-to-earn",
+        title: s.step1?.how_to_earn_title,
+        text: s.step1?.how_to_earn_text,
+        buttons: [
+          { text: s.skip, action: () => this.dismissTutorial(), classes: "shepherd-button-secondary" },
+          { text: s.next, action: () => this.tour.next(), classes: "shepherd-button-primary" }
+        ]
+      },
+      // ステップ6: プロフィールへ遷移
+      {
+        id: "navigate-profile",
+        title: s.step1?.navigate_title,
+        text: s.step1?.navigate_text,
+        attachTo: { element: 'a[href="/profile"]', on: "bottom" },
+        buttons: [
+          { text: s.skip, action: () => this.dismissTutorial(), classes: "shepherd-button-secondary" },
+          {
+            text: s.go_to_profile,
+            action: async () => {
+              await this.advanceCollectionTutorial()
+              window.location.href = "/profile"
+            },
+            classes: "shepherd-button-primary"
+          }
+        ]
+      }
+    ]
+  }
+
+  // ===== フェーズ2: プロフィール画面（/profile） =====
+
+  phase2Steps() {
+    const s = this.i18nValue
+    return [
+      // ステップ7: ダイスコレクショングリッドの説明
+      {
+        id: "collection-grid",
+        title: s.step2?.grid_title,
+        text: s.step2?.grid_text,
+        attachTo: { element: ".row.row-cols-4", on: "top" },
+        buttons: [
+          { text: s.skip, action: () => this.dismissTutorial(), classes: "shepherd-button-secondary" },
+          { text: s.next, action: () => this.tour.next(), classes: "shepherd-button-primary" }
+        ]
+      },
+      // ステップ8: アイコン変更方法の説明
+      {
+        id: "icon-change",
+        title: s.step2?.icon_change_title,
+        text: s.step2?.icon_change_text,
+        attachTo: { element: 'input[type="submit"].btn-primary', on: "top" },
+        buttons: [
+          { text: s.skip, action: () => this.dismissTutorial(), classes: "shepherd-button-secondary" },
+          { text: s.next, action: () => this.tour.next(), classes: "shepherd-button-primary" }
+        ]
+      },
+      // ステップ9: 完了メッセージ
+      {
+        id: "complete",
+        title: s.step2?.complete_title,
+        text: s.step2?.complete_text,
+        buttons: [
+          {
+            text: s.done,
+            action: () => this.dismissTutorial(),
+            classes: "shepherd-button-primary"
+          }
+        ]
+      }
+    ]
+  }
+
+  // ===== サーバー通信 =====
+
+  async advanceCollectionTutorial() {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').content
+    await fetch("/tutorial", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "X-CSRF-Token": csrfToken },
+      body: JSON.stringify({ action_type: "advance_collection" })
+    })
+  }
+
+  async dismissTutorial() {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').content
+    await fetch("/tutorial", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "X-CSRF-Token": csrfToken },
+      body: JSON.stringify({ action_type: "dismiss_collection" })
+    })
+    if (this.tour) this.tour.complete()
+  }
+
+  // ===== z-index 管理 =====
+
+  lowerOverlayZIndex() {
+    const overlay = document.querySelector(".shepherd-modal-overlay-container")
+    if (overlay) overlay.style.setProperty("z-index", "1040", "important")
+  }
+
+  restoreOverlayZIndex() {
+    const overlay = document.querySelector(".shepherd-modal-overlay-container")
+    if (overlay) overlay.style.removeProperty("z-index")
+  }
+
+  // ===== イベントリスナークリーンアップ =====
+
+  cleanupListeners() {
+    if (this.modalShownHandler) {
+      document.removeEventListener("shown.bs.modal", this.modalShownHandler)
+    }
+    if (this.diceModalShownHandler) {
+      document.removeEventListener("shown.bs.modal", this.diceModalShownHandler)
+    }
+    if (this.diceModalHiddenHandler) {
+      document.removeEventListener("hidden.bs.modal", this.diceModalHiddenHandler)
+    }
+    this.restoreOverlayZIndex()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -30,3 +30,6 @@ application.register("completion-popup", CompletionPopupController)
 
 import AutoShowToastController from "./auto_show_toast_controller"
 application.register("auto-show-toast", AutoShowToastController)
+
+import CollectionTutorialController from "./collection_tutorial_controller"
+application.register("collection-tutorial", CollectionTutorialController)

--- a/app/javascript/controllers/tutorial_controller.js
+++ b/app/javascript/controllers/tutorial_controller.js
@@ -382,7 +382,7 @@ export default class extends Controller {
         buttons: [
           {
             text: s.done,
-            action: () => { this.dismissTutorial(); this.tour.complete() },
+            action: () => { this.dismissTutorial() },
             classes: "shepherd-button-primary"
           }
         ]
@@ -392,6 +392,7 @@ export default class extends Controller {
 
   async dismissTutorial() {
     const csrfToken = document.querySelector('meta[name="csrf-token"]').content
+    // 1. 既存チュートリアルを終了
     await fetch("/tutorial", {
       method: "PATCH",
       headers: {
@@ -400,6 +401,17 @@ export default class extends Controller {
       },
       body: JSON.stringify({ action_type: "dismiss" })
     })
+    // 2. コレクションチュートリアルを開始
+    await fetch("/tutorial", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": csrfToken
+      },
+      body: JSON.stringify({ action_type: "start_collection" })
+    })
+    // 3. collection_tutorial_controller に起動を通知
+    document.dispatchEvent(new CustomEvent("collection-tutorial:start"))
     if (this.tour) this.tour.complete()
   }
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,6 +93,7 @@ class User < ApplicationRecord
   end
 
   TUTORIAL_LAST_STEP = 6
+  COLLECTION_TUTORIAL_LAST_STEP = 2
 
   def tutorial_active?
     tutorial_step > 0
@@ -105,6 +106,27 @@ class User < ApplicationRecord
 
   def dismiss_tutorial!
     update!(tutorial_step: 0)
+  end
+
+  def collection_tutorial_active?
+    collection_tutorial_step > 0
+  end
+
+  def any_tutorial_active?
+    tutorial_active? || collection_tutorial_active?
+  end
+
+  def start_collection_tutorial!
+    update!(collection_tutorial_step: 1)
+  end
+
+  def advance_collection_tutorial!
+    next_step = collection_tutorial_step + 1
+    update!(collection_tutorial_step: next_step <= COLLECTION_TUTORIAL_LAST_STEP ? next_step : 0)
+  end
+
+  def dismiss_collection_tutorial!
+    update!(collection_tutorial_step: 0)
   end
 
   def site_icon_path

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,9 +28,14 @@
     <% if user_signed_in? && current_user.tutorial_active? %>
       <meta name="tutorial-step" content="<%= current_user.tutorial_step %>">
     <% end %>
+    <% if user_signed_in? && current_user.collection_tutorial_active? %>
+      <meta name="collection-tutorial-step" content="<%= current_user.collection_tutorial_step %>">
+    <% end %>
   </head>
 
-  <body data-controller="tutorial loading" data-tutorial-i18n-value="<%= t('tutorial').to_json %>">
+  <body data-controller="tutorial loading collection-tutorial"
+        data-tutorial-i18n-value="<%= t('tutorial').to_json %>"
+        data-collection-tutorial-i18n-value="<%= t('collection_tutorial').to_json %>">
     <%# ローディングオーバーレイ（z-index: 9000 でチュートリアル Shepherd より下） %>
     <div class="loading-overlay" data-loading-target="overlay">
       <div class="spinner-border text-light" role="status" style="width: 3rem; height: 3rem;">

--- a/config/locales/views/ja_jp.yml
+++ b/config/locales/views/ja_jp.yml
@@ -147,6 +147,32 @@ ja_jp:
     step6:
       result_title: シミュレーション完了！
       result_text: ここに戦闘結果が表示されます。勝敗・ターン数・攻撃ログを確認できます。これでチュートリアルは完了です！色々な条件でシミュレーションしてみましょう！
+  collection_tutorial:
+    next: 次へ
+    back: 戻る
+    skip: スキップ
+    done: 完了
+    go_to_profile: プロフィールへ
+    step1:
+      ticket_click_title: 特典券を入手しました！
+      ticket_click_text: 特典券バッジをクリックしてみましょう。
+      ticket_use_title: 特典券を使ってみましょう！
+      ticket_use_text: 特典券を使用するとダイスコレクションを入手できます！「特典券を使用する」を押してみましょう。
+      dice_result_title: ダイスを入手しました！
+      dice_result_text: 「閉じる」を押して続けましょう。
+      site_logo_title: ダイスコレクションとは？
+      site_logo_text: 入手したダイスコレクションダイスを、サイトロゴに使用することができます！
+      how_to_earn_title: 特典券の入手方法
+      how_to_earn_text: 特典券はアプリの機能を使用することで入手することができます。
+      navigate_title: プロフィール画面へ
+      navigate_text: プロフィール画面でダイスコレクションを確認できます。実際に見てみましょう！
+    step2:
+      grid_title: ダイスコレクション
+      grid_text: ダイスコレクションを集めることで選べるダイスが増えていきます！
+      icon_change_title: アイコンの変更方法
+      icon_change_text: 解放済みのダイスをクリックして選択し、「ダイスを保存」ボタンを押すとサイトアイコンが変更されます。
+      complete_title: チュートリアル完了！
+      complete_text: ダイスコレクションを集めてサイトを自分好みに彩りましょう！
   users:
     profiles:
       show:

--- a/db/migrate/20260405000001_add_collection_tutorial_step_to_users.rb
+++ b/db/migrate/20260405000001_add_collection_tutorial_step_to_users.rb
@@ -1,0 +1,5 @@
+class AddCollectionTutorialStepToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :collection_tutorial_step, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_04_000003) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_05_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -103,6 +103,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_04_000003) do
     t.integer "simulations_count", default: 0, null: false
     t.integer "character_edits_count", default: 0, null: false
     t.integer "dice_updates_count", default: 0, null: false
+    t.integer "collection_tutorial_step", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -448,4 +448,95 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe 'コレクションチュートリアル' do
+    let(:user) { create(:user) }
+
+    describe '#collection_tutorial_active?' do
+      context 'collection_tutorial_step が 0 の場合' do
+        it 'false を返すこと' do
+          user.update!(collection_tutorial_step: 0)
+          expect(user.collection_tutorial_active?).to be false
+        end
+      end
+
+      context 'collection_tutorial_step が 1 以上の場合' do
+        it 'collection_tutorial_step=1 のとき true を返すこと' do
+          user.update!(collection_tutorial_step: 1)
+          expect(user.collection_tutorial_active?).to be true
+        end
+
+        it 'collection_tutorial_step=2（最終ステップ）のとき true を返すこと' do
+          user.update!(collection_tutorial_step: 2)
+          expect(user.collection_tutorial_active?).to be true
+        end
+      end
+    end
+
+    describe '#any_tutorial_active?' do
+      context '両方のチュートリアルが非活性の場合' do
+        it 'false を返すこと' do
+          user.update!(tutorial_step: 0, collection_tutorial_step: 0)
+          expect(user.any_tutorial_active?).to be false
+        end
+      end
+
+      context '既存チュートリアルのみ活性の場合' do
+        it 'true を返すこと' do
+          user.update!(tutorial_step: 1, collection_tutorial_step: 0)
+          expect(user.any_tutorial_active?).to be true
+        end
+      end
+
+      context 'コレクションチュートリアルのみ活性の場合' do
+        it 'true を返すこと' do
+          user.update!(tutorial_step: 0, collection_tutorial_step: 1)
+          expect(user.any_tutorial_active?).to be true
+        end
+      end
+
+      context '両方のチュートリアルが活性の場合' do
+        it 'true を返すこと' do
+          user.update!(tutorial_step: 1, collection_tutorial_step: 1)
+          expect(user.any_tutorial_active?).to be true
+        end
+      end
+    end
+
+    describe '#start_collection_tutorial!' do
+      it 'collection_tutorial_step を 1 にすること' do
+        user.update!(collection_tutorial_step: 0)
+        user.start_collection_tutorial!
+        expect(user.reload.collection_tutorial_step).to eq 1
+      end
+    end
+
+    describe '#advance_collection_tutorial!' do
+      it 'collection_tutorial_step を 1 インクリメントすること' do
+        user.update!(collection_tutorial_step: 1)
+        expect { user.advance_collection_tutorial! }
+          .to change { user.reload.collection_tutorial_step }.from(1).to(2)
+      end
+
+      it 'collection_tutorial_step=2（最終ステップ）のとき 0 にリセットすること' do
+        user.update!(collection_tutorial_step: 2)
+        user.advance_collection_tutorial!
+        expect(user.reload.collection_tutorial_step).to eq 0
+      end
+    end
+
+    describe '#dismiss_collection_tutorial!' do
+      it 'collection_tutorial_step を 0 にすること' do
+        user.update!(collection_tutorial_step: 1)
+        user.dismiss_collection_tutorial!
+        expect(user.reload.collection_tutorial_step).to eq 0
+      end
+
+      it 'collection_tutorial_step がすでに 0 のとき 0 のままであること' do
+        user.update!(collection_tutorial_step: 0)
+        user.dismiss_collection_tutorial!
+        expect(user.reload.collection_tutorial_step).to eq 0
+      end
+    end
+  end
 end

--- a/spec/requests/grant_tickets_spec.rb
+++ b/spec/requests/grant_tickets_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+# ApplicationController#grant_tickets の抑制条件（any_tutorial_active?）のテスト
+# チュートリアル中（既存 or コレクション）は特典券の付与通知が抑制されることを確認する
+RSpec.describe "GrantTickets（特典券付与の抑制）", type: :request do
+  describe "プロフィール画面（grant_tickets が呼ばれる例）" do
+    context '既存チュートリアル中（tutorial_step > 0）の場合' do
+      let(:user) { create(:user, tutorial_step: 1, collection_tutorial_step: 0) }
+      before { sign_in user }
+
+      it '特典券が付与されないこと' do
+        expect {
+          get profile_path
+        }.not_to change { user.reload.reward_tickets }
+      end
+
+      it 'フラッシュに reward_ticket_granted が設定されないこと' do
+        get profile_path
+        expect(flash[:reward_ticket_granted]).to be_nil
+      end
+    end
+
+    context 'コレクションチュートリアル中（collection_tutorial_step > 0）の場合' do
+      let(:user) { create(:user, tutorial_step: 0, collection_tutorial_step: 1) }
+      before { sign_in user }
+
+      it '特典券が付与されないこと' do
+        expect {
+          get profile_path
+        }.not_to change { user.reload.reward_tickets }
+      end
+
+      it 'フラッシュに reward_ticket_granted が設定されないこと' do
+        get profile_path
+        expect(flash[:reward_ticket_granted]).to be_nil
+      end
+    end
+
+    context '両方のチュートリアルが完了済み（両方とも 0）の場合' do
+      let(:user) { create(:user, tutorial_step: 0, collection_tutorial_step: 0) }
+      before { sign_in user }
+
+      it '初回アクセス時に特典券が付与されること' do
+        expect {
+          get profile_path
+        }.to change { user.reload.reward_tickets }.by(1)
+      end
+
+      it 'フラッシュに reward_ticket_granted が設定されること' do
+        get profile_path
+        expect(flash[:reward_ticket_granted]).to eq 1
+      end
+    end
+  end
+end

--- a/spec/requests/tutorials_spec.rb
+++ b/spec/requests/tutorials_spec.rb
@@ -62,6 +62,68 @@ RSpec.describe "Tutorials", type: :request do
           }.to change { user.reload.tutorial_step }.from(6).to(0)
         end
       end
+
+      context 'action_type=start_collection の場合' do
+        let(:user) { create(:user, collection_tutorial_step: 0) }
+
+        it 'collection_tutorial_step を 1 にすること' do
+          expect {
+            patch tutorial_path, params: { action_type: "start_collection" },
+              as: :json
+          }.to change { user.reload.collection_tutorial_step }.from(0).to(1)
+        end
+
+        it '200 OK を返すこと' do
+          patch tutorial_path, params: { action_type: "start_collection" },
+            as: :json
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context 'action_type=advance_collection の場合' do
+        let(:user) { create(:user, collection_tutorial_step: 1) }
+
+        it 'collection_tutorial_step を 1 進めること' do
+          expect {
+            patch tutorial_path, params: { action_type: "advance_collection" },
+              as: :json
+          }.to change { user.reload.collection_tutorial_step }.from(1).to(2)
+        end
+
+        it '200 OK を返すこと' do
+          patch tutorial_path, params: { action_type: "advance_collection" },
+            as: :json
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context 'action_type=advance_collection で最終ステップ(2)のとき' do
+        let(:user) { create(:user, collection_tutorial_step: 2) }
+
+        it 'collection_tutorial_step が 0 にリセットされること' do
+          expect {
+            patch tutorial_path, params: { action_type: "advance_collection" },
+              as: :json
+          }.to change { user.reload.collection_tutorial_step }.from(2).to(0)
+        end
+      end
+
+      context 'action_type=dismiss_collection の場合' do
+        let(:user) { create(:user, collection_tutorial_step: 1) }
+
+        it 'collection_tutorial_step を 0 にすること' do
+          expect {
+            patch tutorial_path, params: { action_type: "dismiss_collection" },
+              as: :json
+          }.to change { user.reload.collection_tutorial_step }.from(1).to(0)
+        end
+
+        it '200 OK を返すこと' do
+          patch tutorial_path, params: { action_type: "dismiss_collection" },
+            as: :json
+          expect(response).to have_http_status(:ok)
+        end
+      end
     end
 
     context '未認証ユーザーの場合' do


### PR DESCRIPTION
## タイトル
コレクションチュートリアル機能を実装

## 概要
既存チュートリアル（6ステップ）の完了またはスキップ直後に、ダイスコレクション機能の使い方を案内するコレクションチュートリアルを追加した。  
Shepherd.js を用いた2フェーズ構成のチュートリアルで、特典券の使用・ダイス入手・プロフィール画面でのアイコン変更までを誘導する。

## 関連Issue
- close #128

## やったこと（変更点）

### DB / モデル
- `users` テーブルに `collection_tutorial_step` カラム（integer, default: 0）を追加するマイグレーションを作成
- `User` モデルに `collection_tutorial_active?` / `any_tutorial_active?` / `start_collection_tutorial!` / `advance_collection_tutorial!` / `dismiss_collection_tutorial!` メソッドを追加

### コントローラー
- `TutorialsController#update` に `start_collection` / `advance_collection` / `dismiss_collection` の3アクションタイプを追加
- `ApplicationController#grant_tickets` の抑制条件を `tutorial_active?` → `any_tutorial_active?` に変更し、コレクションチュートリアル中も特典券付与通知を抑制

### フロントエンド
- `CollectionTutorialController`（Stimulus）を新規作成
  - フェーズ1（任意ページ）: 特典券バッジクリック → 特典券使用 → ダイス入手確認 → サイトロゴ説明 → 入手方法説明 → プロフィールへ遷移（最大6ステップ、特典券がない場合は後半3ステップのみ）
  - フェーズ2（`/profile`）: ダイスコレクショングリッド説明 → アイコン変更説明 → 完了（3ステップ）
  - Bootstrap モーダルと Shepherd オーバーレイの z-index 競合を管理
- `tutorial_controller.js` を修正: チュートリアル終了時（完了・スキップ両方）にコレクションチュートリアルを開始
- `controllers/index.js` に `CollectionTutorialController` を登録
- `application.html.erb` にコレクションチュートリアル用 meta タグと `data-controller` を追加

### ローカライズ
- `ja_jp.yml` に `collection_tutorial` セクションを追加（全ステップのタイトル・テキスト）

### テスト
- `spec/models/user_spec.rb`: コレクションチュートリアル関連メソッドのテスト11件を追加
- `spec/requests/tutorials_spec.rb`: 新アクションタイプのテスト8件を追加
- `spec/requests/grant_tickets_spec.rb`: 特典券付与抑制条件のテスト6件を新規作成

## 作業サマリー

### 設計方針
既存チュートリアルと独立した「Plan B」方式を採用。専用DBカラム・専用Stimulusコントローラーにより、既存チュートリアルへの影響を最小化している。

### 既知の問題
フェーズ1のステップ2→3・3→4遷移時に、前ステップのポップオーバーが画面左上に一瞬フラッシュする問題が残存している。Shepherd.js がステップごとに新しい `<dialog>` 要素を生成し `when.show` が表示後に発火する特性が原因で、複数のアプローチを試みたが未解決。別Issueで継続対応予定。

## 動作確認
- rubocop　テスト済み
- rspec　テスト済み
- localhost3000/ローカル環境での動作確認済み
- 本番環境 / (render)での動作確認はmainブランチにコミットされた後に確認予定です。

## 注意事項
- マージ後は本番環境でのDBマイグレーション実行が必要です: `bin/rails db:migrate`