### PR TITLE
[#155] コレクションチュートリアルのフェーズ1ステップ3削除と関連挙動の修正

### DIFF
--- a/app/javascript/controllers/collection_tutorial_controller.js
+++ b/app/javascript/controllers/collection_tutorial_controller.js
@@ -18,10 +18,19 @@ export default class extends Controller {
 
   // ===== 起動制御 =====
 
-  tryStart() {
+  async tryStart() {
     const meta = document.querySelector('meta[name="collection-tutorial-step"]')
     if (!meta) return
     const step = parseInt(meta.content, 10)
+
+    // ヘッダーのプロフィールリンク経由で /profile に到達した場合、
+    // フェーズ1完了として扱いフェーズ2を起動する
+    if (step === 1 && window.location.pathname === "/profile") {
+      await this.advanceCollectionTutorial()
+      this.startTour(2)
+      return
+    }
+
     if (!this.shouldShowTour(step)) return
     this.startTour(step)
   }
@@ -89,7 +98,7 @@ export default class extends Controller {
           }
         }
       },
-      // ステップ2: 「特典券を使用する」ボタンをクリックするよう誘導
+      // ステップ2: 「特典券を使用する」ボタンをクリックするよう誘導 (ダイス入手モーダルが閉じられるまで表示し続ける)
       {
         id: "ticket-use",
         title: s.step1?.ticket_use_title,
@@ -99,37 +108,30 @@ export default class extends Controller {
         when: {
           show: () => {
             this.lowerOverlayZIndex()
-            this.diceModalShownHandler = (e) => {
-              if (e.target.id === "diceAcquiredModal") {
-                this.tour.next()
+
+            // 「特典券を使用する」押下 → rewardTicketModal が閉じ始めた瞬間にステップ2を非表示にする
+            // (attachTo 対象消失によるポップオーバーの宙浮きを防ぐ)
+            this.rewardModalHideHandler = (e) => {
+              if (e.target.id === "rewardTicketModal") {
+                const currentStep = this.tour.getCurrentStep()
+                if (currentStep && currentStep.el) {
+                  currentStep.el.style.setProperty("visibility", "hidden", "important")
+                }
               }
             }
-            document.addEventListener("shown.bs.modal", this.diceModalShownHandler)
-          },
-          hide: () => {
-            document.removeEventListener("shown.bs.modal", this.diceModalShownHandler)
-            this.restoreOverlayZIndex()
-          }
-        }
-      },
-      // ステップ3: 入手ダイスモーダルの「閉じる」ボタンをクリックするよう誘導
-      {
-        id: "dice-result",
-        title: s.step1?.dice_result_title,
-        text: s.step1?.dice_result_text,
-        attachTo: { element: "#diceAcquiredModal .modal-footer .btn-primary", on: "top" },
-        buttons: [],
-        when: {
-          show: () => {
-            this.lowerOverlayZIndex()
+            document.addEventListener("hide.bs.modal", this.rewardModalHideHandler)
+
+            // ダイス入手モーダルが閉じられたらステップ4へ遷移
             this.diceModalHiddenHandler = (e) => {
               if (e.target.id === "diceAcquiredModal") {
+                this.restoreOverlayZIndex()
                 this.tour.next()
               }
             }
             document.addEventListener("hidden.bs.modal", this.diceModalHiddenHandler)
           },
           hide: () => {
+            document.removeEventListener("hide.bs.modal", this.rewardModalHideHandler)
             document.removeEventListener("hidden.bs.modal", this.diceModalHiddenHandler)
             this.restoreOverlayZIndex()
           }
@@ -265,8 +267,8 @@ export default class extends Controller {
     if (this.modalShownHandler) {
       document.removeEventListener("shown.bs.modal", this.modalShownHandler)
     }
-    if (this.diceModalShownHandler) {
-      document.removeEventListener("shown.bs.modal", this.diceModalShownHandler)
+    if (this.rewardModalHideHandler) {
+      document.removeEventListener("hide.bs.modal", this.rewardModalHideHandler)
     }
     if (this.diceModalHiddenHandler) {
       document.removeEventListener("hidden.bs.modal", this.diceModalHiddenHandler)

--- a/config/locales/views/ja_jp.yml
+++ b/config/locales/views/ja_jp.yml
@@ -158,8 +158,6 @@ ja_jp:
       ticket_click_text: 特典券バッジをクリックしてみましょう。
       ticket_use_title: 特典券を使ってみましょう！
       ticket_use_text: 特典券を使用するとダイスコレクションを入手できます！「特典券を使用する」を押してみましょう。
-      dice_result_title: ダイスを入手しました！
-      dice_result_text: 「閉じる」を押して続けましょう。
       site_logo_title: ダイスコレクションとは？
       site_logo_text: 入手したダイスコレクションダイスを、サイトロゴに使用することができます！
       how_to_earn_title: 特典券の入手方法


### PR DESCRIPTION
## タイトル
[#155] コレクションチュートリアルのフェーズ1ステップ3削除と関連挙動の修正

## 概要
コレクションチュートリアル フェーズ1の構成を変更し、ステップ3 (`dice-result`) を完全に削除した上で、ステップ4 (`info-site-logo`) の表示タイミングを「ダイスコレクション入手モーダルが閉じられた後」へ変更しました。あわせて、当該変更で発生したステップ2ポップオーバーの宙浮き表示と、ヘッダーのプロフィールリンク経由でフェーズ進行が起こらない問題も修正しています。

## 関連Issue
- 関連Issue: #155
- close #155

## 原因と対処法（バグ修正の場合）

### 1. フェーズ1ステップ2→3→4 遷移時のフラッシュ問題
- **原因**: ステップ3の `attachTo` が Bootstrap モーダル内要素 (`#diceAcquiredModal .modal-footer .btn-primary`) であり、ステップ遷移時に attachTo 対象が `display:none` となることで Floating UI がフォールバック位置 (画面左上) にポップオーバーを配置していた。
- **対処**: 要件どおりステップ3を完全削除し、ステップ2の遷移契機を `shown.bs.modal` (diceAcquiredModal) → `hidden.bs.modal` に変更。モーダル内 attachTo を持つステップを構造的に消滅させ、フラッシュ問題を根本解消。

### 2. ステップ2ポップオーバーがモーダル切替中に画面左上で宙浮きする問題
- **原因**: 「特典券を使用する」クリック → `rewardTicketModal` 閉鎖 → ステップ2の attachTo 対象 (`#rewardTicketModal .btn-warning`) が消失 → Turbo Stream で `diceAcquiredModal` が表示される間、ポップオーバーがフォールバック位置に表示されていた。
- **対処**: `rewardTicketModal` の `hide.bs.modal` を契機に、現在ステップの DOM 要素へ `style.setProperty(\"visibility\", \"hidden\", \"important\")` を適用してポップオーバーを即座に非表示化。

### 3. ヘッダーのプロフィールリンク経由でフェーズが進まない問題
- **原因**: ツアー内「プロフィールへ」ボタンは `advanceCollectionTutorial()` でサーバー側 `collection_tutorial_step` を 2 に更新してから遷移するのに対し、ヘッダーリンクは素の遷移のため step が 1 のまま `/profile` に到達し、フェーズ1が再開されていた。
- **対処**: `tryStart()` を async 化し、`step === 1 && pathname === \"/profile\"` の場合に `advanceCollectionTutorial()` を await してからフェーズ2を起動する分岐を追加。

## やったこと（変更点）

- [app/javascript/controllers/collection_tutorial_controller.js](app/javascript/controllers/collection_tutorial_controller.js)
  - フェーズ1ステップ3 (`dice-result`) のオブジェクトを完全削除
  - ステップ2 (`ticket-use`) の `when.show`/`when.hide` を `hidden.bs.modal` (diceAcquiredModal) 監視に変更し、`tour.next()` 直前で `restoreOverlayZIndex()` を呼ぶよう調整
  - ステップ2に `hide.bs.modal` (rewardTicketModal) リスナーを追加し、モーダル閉鎖時にステップ2のポップオーバーを `visibility: hidden !important` で即時非表示
  - `tryStart()` を async 化し、ヘッダー経由 `/profile` 遷移時に自動でフェーズ2を起動する分岐を追加
  - `cleanupListeners()` から不要な `diceModalShownHandler` 参照を削除し、新規 `rewardModalHideHandler` の解除処理を追加
- [config/locales/views/ja_jp.yml](config/locales/views/ja_jp.yml)
  - 削除したステップ3で参照していた i18n キー `step1.dice_result_title` / `step1.dice_result_text` を削除

## 動作確認

- rubocop　テスト済み
- rspec　テスト済み
- localhost3000/ローカル環境での動作確認済み
  - 特典券保有ユーザーで以下を確認:
    - 🎫バッジクリック → ステップ1表示
    - 特典券モーダル表示 → ステップ2表示
    - 「特典券を使用する」クリック → ステップ2が即時非表示 (左上での宙浮きなし)
    - ダイス入手モーダル表示中もポップオーバーは見えない
    - ダイス入手モーダル閉鎖 → ステップ4 (サイトロゴ説明) へ直接遷移
    - フェーズ1のステップ5・6 が従来どおり動作
    - ツアー内「プロフィールへ」ボタン経由でフェーズ2が起動
    - ヘッダーのユーザー名リンク経由でも `/profile` 到達時にフェーズ2が起動 (フェーズ1ステップ4が再表示されない)
  - フェーズ2 (`/profile`) のチュートリアル (ステップ7-9) が従来どおり動作
- 本番環境 / (render)での動作確認はmainブランチにコミットされた後に確認予定です。(mainブランチにコミット時に更新されるため)

## 注意事項
- 特になし (DBマイグレーション・依存追加なし)

---

## 作業サマリー
- 調査: ISSUE #155 の要件と調査レポートを踏まえ、3案を比較検討の上「案A: ステップ3削除＋ステップ2遷移契機を `hidden.bs.modal` に変更」を採用
- 詳細設計: 構造的にモーダル内 attachTo ステップを消すことでフラッシュ問題を根本対処する方針を確定
- 追加修正: 実機確認で判明した2件の追加課題 (ステップ2宙浮き / ヘッダー経由のフェーズ未進行) について、それぞれ最小変更で対処
- 影響範囲: コントローラ1ファイル + i18n 1ファイルのみ。フェーズ2やその他チュートリアル/トースト/モーダルとの競合なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)